### PR TITLE
Allow custom handleError option

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,12 @@ var merge = require('merge');
 var vfs = require('vinyl-fs');
 
 module.exports = function (options) {
-	options = merge({}, defaultOptions, options);
+	options = merge({
+		handleError: handleError
+	}, defaultOptions, options);
+
 	var stream = vfs.src(options.src)
-		.pipe(compileSoy(options).on('error', handleError))
+		.pipe(compileSoy(options).on('error', options.handleError))
 		.pipe(vfs.dest(options.dest));
 	if (!options.skipConsume) {
 		consume(stream);

--- a/test/index.js
+++ b/test/index.js
@@ -79,6 +79,19 @@ describe('Metal Tools - Soy', function() {
         done();
       });
     });
+
+    it('should use custom handleError function', function(done) {
+      var stream = metalToolsSoy({
+        dest: 'test/fixtures/soy',
+        handleError: function(err) {
+          assert.ok(err);
+          assert.ok(err.message);
+
+          done();
+        },
+        src: 'test/fixtures/soy/compileError.soy'
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Note: the reason for not adding the default value of `handleError` to `lib/options.js` is because those options are also passed to `lib/pipelines/compileSoy.js`, which would not implement it.