### PR TITLE
External msg format

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   dest: 'src',
+  externalMsgFormat: '',
   outputDir: '/tmp/metal-tools-soy',
   skipMetalGeneration: false,
   soyDeps: 'node_modules/metal*/src/**/*.soy',

--- a/lib/pipelines/compileSoy.js
+++ b/lib/pipelines/compileSoy.js
@@ -20,6 +20,8 @@ var PATH_TO_JAR = path.resolve(__dirname, '../../jar/soy-2017-02-01-SoyToIncreme
 var parsedSoys = {};
 var templateData = {};
 
+const EXTERNAL_MSG_REGEX = /var MSG_EXTERNAL_([^\s]*) = goog.getMsg\('([^)]*)'\);$/gm;
+
 module.exports = function(options) {
 	options = merge({}, defaultOptions, options);
 
@@ -38,7 +40,8 @@ module.exports = function(options) {
 			header: getHeaderContent,
 			footer: getFooterContent
 		})),
-		gulpif(!options.skipMetalGeneration, replaceTemplateRequires())
+		gulpif(!options.skipMetalGeneration, replaceTemplateRequires()),
+		gulpif(!options.skipMetalGeneration && options.externalMsgFormat !== '', replace(EXTERNAL_MSG_REGEX, 'var MSG_EXTERNAL_$1 = ' + options.externalMsgFormat + ';'))
 	);
 };
 

--- a/lib/pipelines/compileSoy.js
+++ b/lib/pipelines/compileSoy.js
@@ -20,7 +20,7 @@ var PATH_TO_JAR = path.resolve(__dirname, '../../jar/soy-2017-02-01-SoyToIncreme
 var parsedSoys = {};
 var templateData = {};
 
-const EXTERNAL_MSG_REGEX = /var MSG_EXTERNAL_([^\s]*) = goog.getMsg\('([^)]*)'\);$/gm;
+const EXTERNAL_MSG_REGEX = /var (MSG_EXTERNAL_\d+(?:\$\$\d+)?) = goog\.getMsg\(\s*'([\w-\{\}\$]+)'\s*(?:,\s*\{([\s\S]+?)\})?\);/g;
 
 module.exports = function(options) {
 	options = merge({}, defaultOptions, options);
@@ -41,7 +41,7 @@ module.exports = function(options) {
 			footer: getFooterContent
 		})),
 		gulpif(!options.skipMetalGeneration, replaceTemplateRequires()),
-		gulpif(!options.skipMetalGeneration && options.externalMsgFormat !== '', replace(EXTERNAL_MSG_REGEX, 'var MSG_EXTERNAL_$1 = ' + options.externalMsgFormat + ';'))
+		gulpif(!options.skipMetalGeneration && options.externalMsgFormat !== '', replace(EXTERNAL_MSG_REGEX, 'var $1 = ' + options.externalMsgFormat + ';'))
 	);
 };
 

--- a/test/fixtures/soy/messages.soy
+++ b/test/fixtures/soy/messages.soy
@@ -1,0 +1,10 @@
+{namespace Messages}
+
+/**
+ */
+{template .render}
+	{msg desc=""}foo{/msg}
+	{msg desc=""}bar{/msg}
+	{msg desc=""}foo{/msg}
+	{msg desc=""}complex-key{/msg}
+{/template}

--- a/test/lib/pipelines/compileSoy.js
+++ b/test/lib/pipelines/compileSoy.js
@@ -182,6 +182,34 @@ describe('Compile Soy Pipeline', function() {
     });
 	});
 
+	it('should not replace google external messages by default', function(done) {
+		var stream = vfs.src('test/fixtures/soy/messages.soy')
+			.pipe(compileSoy());
+		stream.on('data', function(file) {
+			var contents = file.contents.toString();
+
+			assert.strictEqual(4, contents.match(/var MSG_EXTERNAL_(?:[^\s]*)\s=\sgoog.getMsg/g).length);
+			done();
+		});
+	});
+
+	it('should replace external messages from goog.getMsg calls if an externalMsgFormat has been specified', function(done) {
+		var externalMsgFormat = 'I18n.translate(\'$2\')';
+
+		var stream = vfs.src('test/fixtures/soy/messages.soy')
+			.pipe(compileSoy({
+				externalMsgFormat: externalMsgFormat
+			}));
+		stream.on('data', function(file) {
+			var contents = file.contents.toString();
+
+			assert.strictEqual(2, contents.match(/var MSG_EXTERNAL_(?:[^\s]*)\s=\sI18n.translate\('foo'\)/g).length);
+			assert.strictEqual(1, contents.match(/var MSG_EXTERNAL_(?:[^\s]*)\s=\sI18n.translate\('bar'\)/g).length);
+			assert.strictEqual(1, contents.match(/var MSG_EXTERNAL_(?:[^\s]*)\s=\sI18n.translate\('complex-key'\)/g).length);
+			done();
+		});
+	});
+
 	it('should emit error and end stream when soy parsing error is thrown', function(done) {
     var stream = vfs.src('test/fixtures/soy/parseError.soy')
       .pipe(compileSoy());


### PR DESCRIPTION
Hey @eduardolundgren, @mthadley, this PR adds support for an `externalMsgFormat` option that can be used to replace the extracted messages by the soy compiler.

For example, for `externalMsgFormat: "I18n.translate('$2').replace('a', 'A')"` it would turn generated output like:

```javascript
var MSG_EXTERNAL_1234123123123 = goog.getMsg('foo-bar');
```
into
```javascript
var MSG_EXTERNAL_1234123123123 = I18n.translate('foo-bar').replace('a', 'A');
``` 

We are currently doing this via `Gradle` after all the compile steps have happened in https://github.com/liferay/liferay-portal/blob/master/modules/util/portal-tools-soy-builder/src/main/java/com/liferay/portal/tools/soy/builder/commands/ReplaceSoyTranslationCommand.java, but it would be nice if we could do it in just one step while we're compiling soy so we can also make sure changes in the compiler won't break client code.

What do you think?