### PR TITLE
Updates SoyToIncrementalDomSrcCompiler to release-2017-04-24

### DIFF
--- a/lib/pipelines/compileSoy.js
+++ b/lib/pipelines/compileSoy.js
@@ -15,7 +15,7 @@ var soyparser = require('soyparser').default;
 var through = require('through2');
 var wrapper = require('gulp-wrapper');
 
-var PATH_TO_JAR = path.resolve(__dirname, '../../jar/soy-2017-02-01-SoyToIncrementalDomSrcCompiler.jar');
+var PATH_TO_JAR = path.resolve(__dirname, '../../jar/soy-2017-04-23-SoyToIncrementalDomSrcCompiler.jar');
 
 var parsedSoys = {};
 var templateData = {};


### PR DESCRIPTION
This updates the `SoyToIncrementalDomSrcCompiler` to https://github.com/google/closure-templates/commit/25806529e41f0abf9bd45f2b80fdc4d825062b67.

@eduardolundgren, I considered waiting for a more official release, but it's been over a month of this sprint, so I think it should be safe, and all tests are passing...