### PR TITLE
Fixes regexp for external namespaced templates

### DIFF
--- a/lib/pipelines/__tests__/__snapshots__/compileSoy.js.snap
+++ b/lib/pipelines/__tests__/__snapshots__/compileSoy.js.snap
@@ -893,6 +893,64 @@ export default templates;
 /* jshint ignore:end */
 `;
 
+exports[`Compile Soy Pipeline should replace goog.require calls to other namespaced templates with Soy.getTemplate calls 1`] = `
+/* jshint ignore:start */
+import Component from 'metal-component';
+import Soy from 'metal-soy';
+
+var templates;
+goog.loadModule(function(exports) {
+  var soy = goog.require('soy');
+  var soydata = goog.require('soydata');
+  // This file was automatically generated from externalCompound.soy.
+  // Please don't edit this file by hand.
+
+  /**
+   * @fileoverview Templates in namespace ExternalCompound.
+   * @public
+   */
+
+  goog.module('ExternalCompound.incrementaldom');
+
+  var soyIdom = goog.require('soy.idom');
+  var $import1 = goog.require('Compound.Name.incrementaldom');
+  var $templateAlias1 = Soy.getTemplate('undefined.incrementaldom', 'render');
+
+
+  /**
+   * @param {Object<string, *>=} opt_data
+   * @param {Object<string, *>=} opt_ijData
+   * @param {Object<string, *>=} opt_ijData_deprecated
+   * @return {void}
+   * @suppress {checkTypes}
+   */
+  function $render(opt_data, opt_ijData, opt_ijData_deprecated) {
+    opt_ijData = opt_ijData_deprecated || opt_ijData;
+    opt_data = opt_data || {};
+    $templateAlias1(opt_data, null, opt_ijData);
+  }
+  exports.render = $render;
+  if (goog.DEBUG) {
+    $render.soyTemplateName = 'ExternalCompound.render';
+  }
+
+  exports.render.params = [];
+  exports.render.types = {};
+  templates = exports;
+  return exports;
+
+});
+
+class ExternalCompound extends Component {}
+Soy.register(ExternalCompound, templates);
+export {
+  ExternalCompound,
+  templates
+};
+export default templates;
+/* jshint ignore:end */
+`;
+
 exports[`Compile Soy Pipeline should replace goog.require calls to other templates with Soy.getTemplate calls 1`] = `
 /* jshint ignore:start */
 import Component from 'metal-component';

--- a/lib/pipelines/__tests__/__snapshots__/compileSoy.js.snap
+++ b/lib/pipelines/__tests__/__snapshots__/compileSoy.js.snap
@@ -913,8 +913,8 @@ goog.loadModule(function(exports) {
   goog.module('ExternalCompound.incrementaldom');
 
   var soyIdom = goog.require('soy.idom');
-  var $import1 = goog.require('Compound.Name.incrementaldom');
-  var $templateAlias1 = Soy.getTemplate('undefined.incrementaldom', 'render');
+
+  var $templateAlias1 = Soy.getTemplate('Compound.Name.incrementaldom', 'render');
 
 
   /**

--- a/lib/pipelines/__tests__/compileSoy.js
+++ b/lib/pipelines/__tests__/compileSoy.js
@@ -299,6 +299,38 @@ describe('Compile Soy Pipeline', function() {
 		});
 	});
 
+	it('should replace goog.require calls to other namespaced templates with Soy.getTemplate calls', function(
+		done
+	) {
+		const stream = vfs
+			.src([
+				'test/fixtures/soy/externalCompound.soy',
+				'test/fixtures/soy/CompoundName.soy'
+			])
+			.pipe(compileSoy());
+		const files = [];
+		stream.on('data', function(file) {
+			files.push(file);
+		});
+		stream.on('end', function() {
+			expect(files.length).toBe(2);
+			expect(files[0].relative).toBe('externalCompound.soy.js');
+			expect(files[1].relative).toBe('CompoundName.soy.js');
+
+			const contents = files[0].contents.toString();
+
+			expect(
+				contents.indexOf(
+					`Soy.getTemplate('Compound.Name.incrementaldom', 'render')`
+				)
+			).not.toBe(-1);
+
+			expect(files[0]).toMatchSnapshot();
+
+			done();
+		});
+	});
+
 	it('should not replace google external messages by default', function(
 		done
 	) {

--- a/lib/pipelines/compileSoy.js
+++ b/lib/pipelines/compileSoy.js
@@ -23,6 +23,7 @@ const PATH_TO_JAR = path.resolve(
 let parsedSoys = {};
 let templateData = {};
 
+// eslint-disable-next-line
 const EXTERNAL_MSG_REGEX = /var (MSG_EXTERNAL_\d+(?:\$\$\d+)?) = goog\.getMsg\(\s*'([\w-\{\}\$]+)'\s*(?:,\s*\{([\s\S]+?)\})?\);/g;
 
 const SOY_HEADER = `/* jshint ignore:start */
@@ -246,7 +247,7 @@ function replaceTemplateRequires() {
 		let contents = file.contents.toString();
 
 		const importMap = {};
-		const requireRegex = /var\s+\$import(\d*)\s*=\s*goog\.require\('(\w+)\.incrementaldom'\);/g;
+		const requireRegex = /var\s+\$import(\d*)\s*=\s*goog\.require\('([\w.]+)\.incrementaldom'\);/g;
 		contents = contents.replace(requireRegex, function(match, id, name) {
 			importMap[id] = name;
 			return '';

--- a/test/fixtures/soy/externalCompound.soy
+++ b/test/fixtures/soy/externalCompound.soy
@@ -1,0 +1,7 @@
+{namespace ExternalCompound}
+
+/**
+ */
+{template .render}
+	{call Compound.Name.render data="all" /}
+{/template}


### PR DESCRIPTION
Hey @Robert-Frampton, I found this while using some external namespaces of the form `foo.bar.MyTemplate`.

See the [difference in the snapshot](https://github.com/metal/metal-tools-soy/pull/32/commits/1a670d4650391acd8a59ca2cf5d680fdb5691524#diff-31e8ed611da145c45d62f34f34df1e93L917)

I've created a `4.x` branch so we can merge and release from there... maybe also need to frontport to `master`, but we haven't properly set this up in this repo.